### PR TITLE
Fixed a typo

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,12 @@
 {
   "name": "vscode-extension-profiles",
-  "version": "1.0.0-rc.3",
+  "version": "1.0.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "1.0.0-rc.3",
+      "name": "vscode-extension-profiles",
+      "version": "1.0.6",
       "license": "Apache-2.0",
       "dependencies": {
         "@mapbox/node-pre-gyp": "^1.0.5",

--- a/package.json
+++ b/package.json
@@ -54,9 +54,9 @@
         "shortTitle": "Create profile"
       },
       {
-        "command": "vscode-extension-profiles.Edite",
-        "title": "Extension profiles: Edite profile",
-        "shortTitle": "Edite profile"
+        "command": "vscode-extension-profiles.Edit",
+        "title": "Extension profiles: Edit profile",
+        "shortTitle": "Edit profile"
       },
       {
         "command": "vscode-extension-profiles.Refresh",
@@ -73,7 +73,7 @@
   "activationEvents": [
     "onCommand:vscode-extension-profiles.Apply",
     "onCommand:vscode-extension-profiles.Create",
-    "onCommand:vscode-extension-profiles.Edite",
+    "onCommand:vscode-extension-profiles.Edit",
     "onCommand:vscode-extension-profiles.Delete",
     "onCommand:vscode-extension-profiles.Refresh",
     "onStartupFinished"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vscode-extension-profiles",
   "displayName": "Extension profiles",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "private": false,
   "description": "Lets you create profiles to include the selected extensions in the desired project.",
   "categories": [

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -29,7 +29,7 @@ export async function applyProfile() {
   }
 
   // Selected profile
-  let profileName = (await vscode.window.showQuickPick(itemsProfiles, { placeHolder: "Search" , title:"Select a profile"}))?.label;
+  let profileName = (await vscode.window.showQuickPick(itemsProfiles, { placeHolder: "Search", title: "Select a profile" }))?.label;
   if (!profileName) {
     return;
   }
@@ -70,8 +70,8 @@ export async function applyProfile() {
   await setWorkspaceStorageValue(uuid, "disabled", disabledList);
 
   // Reloading the window to apply extensions
-   vscode.commands.executeCommand("workbench.action.reloadWindow");
-   return;
+  vscode.commands.executeCommand("workbench.action.reloadWindow");
+  return;
 }
 
 // Create profile ...
@@ -134,8 +134,8 @@ export async function createProfile() {
   return vscode.window.showInformationMessage(`Profile "${profileName}" successfully created!`);
 }
 
-// Edite profile ...
-export async function editeProfile() {
+// Edit profile ...
+export async function editProfile() {
   // Get and check profiles
   const profiles = await getProfileList();
   if (Object.keys(profiles).length === 0) {
@@ -152,7 +152,7 @@ export async function editeProfile() {
   }
 
   // Selected profile
-  let profileName = (await vscode.window.showQuickPick(itemsProfiles, { placeHolder: "Search" , title:"Select a profile to edit"}))?.label;
+  let profileName = (await vscode.window.showQuickPick(itemsProfiles, { placeHolder: "Search", title: "Select a profile to edit" }))?.label;
   if (!profileName) {
     return;
   }
@@ -222,7 +222,7 @@ export async function deleteProfile() {
   }
 
   // Selected profile
-  let profileName = (await vscode.window.showQuickPick(itemsProfiles, { placeHolder: "Search" , title:"Select a profile to edit"}))?.label;
+  let profileName = (await vscode.window.showQuickPick(itemsProfiles, { placeHolder: "Search", title: "Select a profile to edit" }))?.label;
   if (!profileName) {
     return;
   }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,6 +1,6 @@
 "use strict";
 import * as vscode from "vscode";
-import { applyProfile, createProfile, deleteProfile, editeProfile, refreshExtensionList } from "./commands";
+import { applyProfile, createProfile, deleteProfile, editProfile, refreshExtensionList } from "./commands";
 import { CommandType } from "./types";
 
 export async function activate(ctx: vscode.ExtensionContext) {
@@ -12,9 +12,9 @@ export async function activate(ctx: vscode.ExtensionContext) {
     vscode.commands.registerCommand("vscode-extension-profiles.Refresh" as CommandType, () => refreshExtensionList({})),
     vscode.commands.registerCommand("vscode-extension-profiles.Create" as CommandType, createProfile),
     vscode.commands.registerCommand("vscode-extension-profiles.Apply" as CommandType, applyProfile),
-    vscode.commands.registerCommand("vscode-extension-profiles.Edite" as CommandType, editeProfile),
+    vscode.commands.registerCommand("vscode-extension-profiles.Edit" as CommandType, editProfile),
     vscode.commands.registerCommand("vscode-extension-profiles.Delete" as CommandType, deleteProfile),
   );
 }
 
-export function deactivate() {}
+export function deactivate() { }

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,7 +4,7 @@ export type ExtensionValue = { id: string; uuid: string; label?: string; descrip
 export type CommandType =
   "vscode-extension-profiles.Refresh" |
   "vscode-extension-profiles.Create" |
-  "vscode-extension-profiles.Edite" |
+  "vscode-extension-profiles.Edit" |
   "vscode-extension-profiles.Apply" |
   "vscode-extension-profiles.Delete";
 
@@ -21,16 +21,16 @@ export type ExtensionList = {
 };
 
 export type PackageJson = {
-	"name": string,
-	"displayName": string,
+  "name": string,
+  "displayName": string,
   "description": string,
   "version": string,
   "publisher": string,
   // eslint-disable-next-line @typescript-eslint/naming-convention
   "__metadata": {
-		"id": string,
-		"publisherId": string,
-		"publisherDisplayName": string,
+    "id": string,
+    "publisherId": string,
+    "publisherDisplayName": string,
     "installedTimestamp": number
   },
   [key: string]: any


### PR DESCRIPTION
Fixed a type in the command name "Edit profile". It was "Edite profile", so I decided to change it to a proper form. There are some cosmetic changes (basically spaces and tabs here and there) that came from me using an autoformatter, but they don't seem to be too aggressive and are quite helpful. I've tested the extension and it works as expected.