### PR TITLE
Feature/create clone profile command

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,6 +57,11 @@
         "shortTitle": "Create profile"
       },
       {
+        "command": "vscode-extension-profiles.Clone",
+        "title": "Extension profiles: Clone profile",
+        "shortTitle": "Clone profile"
+      },
+      {
         "command": "vscode-extension-profiles.Edit",
         "title": "Extension profiles: Edit profile",
         "shortTitle": "Edit profile"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vscode-extension-profiles",
   "displayName": "Extension profiles",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "private": false,
   "description": "Lets you create profiles to include the selected extensions in the desired project.",
   "categories": [
@@ -91,6 +91,7 @@
   "activationEvents": [
     "onCommand:vscode-extension-profiles.Apply",
     "onCommand:vscode-extension-profiles.Create",
+    "onCommand:vscode-extension-profiles.Clone",
     "onCommand:vscode-extension-profiles.Edit",
     "onCommand:vscode-extension-profiles.Delete",
     "onCommand:vscode-extension-profiles.Refresh",

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -120,6 +120,11 @@ export async function createProfile() {
 export async function cloneProfile() {
   const profiles = await getProfileList();
 
+  const selectedProfile = await vscode.window.showQuickPick(Object.keys(profiles))
+  if (!selectedProfile) {
+    return
+  }
+
   // set name profile
   let profileName;
   let placeHolder = "Come up with a profile name";

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -144,7 +144,9 @@ export async function cloneProfile() {
 
   // Get extension list of cache
   let extensions = await getExtensionList();
-
+  // Get ExtensionsList from selected profile to use as prefilled selections
+  const preloadedExtensions = profiles[selectedProfile]
+  
   // update if not exist
   if (Object.keys(extensions).length === 0)
     extensions = await refreshExtensionList({ isCache: true });
@@ -154,6 +156,7 @@ export async function cloneProfile() {
   for (const key in extensions) {
     let item = extensions[key];
     itemsWorkspace.push({
+      picked: !!preloadedExtensions[key],
       label: item.label || key,
       description: item.label ? key : undefined,
       detail: item.description || " - - - - - ",

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -116,6 +116,9 @@ export async function createProfile() {
   return vscode.window.showInformationMessage(`Profile "${profileName}" successfully created!`);
 }
 
+// Copy profile ...
+export async function cloneProfile() {}
+
 // Edit profile ...
 export async function editProfile() {
   // Get and check profiles

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,6 +1,6 @@
 "use strict";
 import * as vscode from "vscode";
-import { applyProfile, createProfile, deleteProfile, editProfile, exportProfile, importProfile, refreshExtensionList } from "./commands";
+import { applyProfile, cloneProfile, createProfile, deleteProfile, editProfile, exportProfile, importProfile, refreshExtensionList } from "./commands";
 import { CommandType } from "./types";
 import { checkGlobalProfile, setEnv } from "./utils";
 
@@ -15,6 +15,7 @@ export async function activate(ctx: vscode.ExtensionContext) {
   ctx.subscriptions.push(
     vscode.commands.registerCommand("vscode-extension-profiles.Refresh" as CommandType, () => refreshExtensionList({})),
     vscode.commands.registerCommand("vscode-extension-profiles.Create" as CommandType, createProfile),
+    vscode.commands.registerCommand("vscode-extension-profiles.Clone" as CommandType, cloneProfile),
     vscode.commands.registerCommand("vscode-extension-profiles.Apply" as CommandType, applyProfile),
     vscode.commands.registerCommand("vscode-extension-profiles.Edit" as CommandType, editProfile),
     vscode.commands.registerCommand("vscode-extension-profiles.Delete" as CommandType, deleteProfile),

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -54,7 +54,6 @@ export async function setWorkspaceStorageValue(key: "enabled" | "disabled", exte
   return await db.run("INSERT OR REPLACE INTO ItemTable (key, value) VALUES (?, ?)", `extensionsIdentifiers/${key}`, JSON.stringify(extensions));
 }
 
-
 export async function setGlobalStorageValue(key: StorageKey, value: ExtensionList | ProfileList) {
   const db = await open({
     filename: `${process.env.VXP_GLOBAL_STORAGE_PATH}state.vscdb`,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -180,7 +180,7 @@ function sortObjectByKey(obj: any) {
 }
 
 export async function getProfileList() {
-  return sortObjectByKey(await getGlobalStorageValue("vscodeExtensionProfiles/profiles") as ProfileList);
+  return sortObjectByKey(await getGlobalStorageValue("vscodeExtensionProfiles/profiles")) as ProfileList;
 }
 
 export async function getExtensionList() {


### PR DESCRIPTION
Hi there!

I started using this extension recently and really liked it but wanted a way to clone or copy existing profiles. I saw this [issue](https://github.com/evald24/vscode-extensions-profiles/issues/33) too, so figured I'd take a stab at it.

I started poking around the code to see how it worked and realized I could essentially just copy what the `createProfile` command is already doing but add the ability to select an existing profile and pre-select all it's extensions when selecting the extensions to load on it.

It's a pretty simple and rudimentary change but it works for my needs so I thought I'd send a pr in case others could use it too.

The heart of the PR is the combination of these two commits:

- [prompt user for prof to clone](https://github.com/evald24/vscode-extensions-profiles/commit/ccb77bfb6a32cb912de6b87b2b6baf2c660d9030)
- [pick exts from selected prof](https://github.com/evald24/vscode-extensions-profiles/commit/7bb687a8e9e275ffe9f6c5bfaf665e71fad5695c)

I think ideally you'd probably want to share more of the code between the `createProfile` and this `cloneProfile` in case their logic ever needs to change but can probably get cleaned up if that ever happens.

Thanks for this extension!